### PR TITLE
Fix password key mismatch in registration

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -73,7 +73,7 @@ class AuthController{
                 'first_name' => $firstName,
                 'last_name' => $lastName, 
                 'email' => $email, 
-                'password' => $password,
+                'hashedPass' => $hashPass,
                 'phone_number' => $phoneNum 
             ]);
 


### PR DESCRIPTION
# Filing a pull request

> [!IMPORTANT]
> Do not create a pull request without creating an issue first (except if you are an officer of CITE). Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

**Types of change**

<!--- What types of change does your work introduce? -->
<!--- Place an 'X' between the brackets to check the item -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds or enhances functionality)
-   [ ] Documentation (non-breaking change which adds or changes documentation)
-   [ ] Refactor (non-breaking change that refactors a section of work)
-   [ ] Breaking change (either of the above that would cause existing functionality to not work as expected)

**Description**

<!--- Describe your changes in detail. Please link the issue ID as well. -->

Fixed a logical error in the registration flow where AuthController was passing the user's password using the key `hashedPass`, but UserModel was expecting the key `password`. This mismatch caused an "Undefined Array Key" error and prevented successful user registration.