### PR TITLE
Bugfix/no ref/fix invalid CSRF large upload on lost and found item post form

### DIFF
--- a/src/Controllers/FoundItemController.php
+++ b/src/Controllers/FoundItemController.php
@@ -103,6 +103,13 @@ class FoundItemController
 
     public static function submitPostForm()
     {
+        // Check for oversized uploads before CSRF validation
+        if (empty($_POST) && !empty($_SERVER['CONTENT_LENGTH'])) {
+            $maxPost = ini_get('post_max_size');
+            http_response_code(413); // Payload Too Large
+            die("Uploaded file is too large. Maximum allowed size is {$maxPost}.");
+        }
+
         if (!Router::isCsrfValid()) {
             http_response_code(403);
             die("Security Error: Invalid CSRF Token. Please refresh the page and try again.");

--- a/src/Controllers/FoundItemController.php
+++ b/src/Controllers/FoundItemController.php
@@ -106,8 +106,11 @@ class FoundItemController
         // Check for oversized uploads before CSRF validation
         if (empty($_POST) && !empty($_SERVER['CONTENT_LENGTH'])) {
             $maxPost = ini_get('post_max_size');
-            http_response_code(413); // Payload Too Large
-            die("Uploaded file is too large. Maximum allowed size is {$maxPost}.");
+            $_SESSION['flash'] = [
+                'error' => "Uploaded file is too large. Maximum allowed size is {$maxPost}."
+            ];
+            header('Location: /found/post');
+            exit;
         }
 
         if (!Router::isCsrfValid()) {

--- a/src/Controllers/LostItemController.php
+++ b/src/Controllers/LostItemController.php
@@ -113,8 +113,11 @@ class LostItemController
         // Check for oversized uploads before CSRF validation
         if (empty($_POST) && !empty($_SERVER['CONTENT_LENGTH'])) {
             $maxPost = ini_get('post_max_size');
-            http_response_code(413); // Payload Too Large
-            die("Uploaded file is too large. Maximum allowed size is {$maxPost}.");
+            $_SESSION['flash'] = [
+                'error' => "Uploaded file is too large. Maximum allowed size is {$maxPost}."
+            ];
+            header('Location: /lost/post');
+            exit;
         }
 
         // CSRF validation

--- a/src/Controllers/LostItemController.php
+++ b/src/Controllers/LostItemController.php
@@ -110,6 +110,13 @@ class LostItemController
 
     public static function submitPostForm()
     {
+        // Check for oversized uploads before CSRF validation
+        if (empty($_POST) && !empty($_SERVER['CONTENT_LENGTH'])) {
+            $maxPost = ini_get('post_max_size');
+            http_response_code(413); // Payload Too Large
+            die("Uploaded file is too large. Maximum allowed size is {$maxPost}.");
+        }
+
         // CSRF validation
         if (!Router::isCsrfValid()) {
             http_response_code(403);
@@ -222,11 +229,6 @@ class LostItemController
 
             // 7) Image upload
             // SIZE LIMIT handled in php.ini (post_max_size / upload_max_filesize)
-            if (empty($_FILES) && !empty($_SERVER['CONTENT_LENGTH'])) {
-                $maxPost = ini_get('post_max_size');
-                throw new Exception("Uploaded file is too large. Maximum allowed size is {$maxPost}.");
-            }
-
             if (!isset($_FILES['item_image'])) {
                 throw new Exception('Please upload an image.');
             }

--- a/src/Views/lost/post.php
+++ b/src/Views/lost/post.php
@@ -28,11 +28,13 @@
     <h2>Post a Lost Item</h2>
 
     <?php if (!empty($flash['error'])): ?>
+        <div id="flash-error">
             <strong>Error:</strong> <?= htmlspecialchars($flash['error']) ?>
         </div>
     <?php endif; ?>
 
     <?php if (!empty($flash['success'])): ?>
+        <div id="flash-success">
             <strong>Success:</strong> <?= htmlspecialchars($flash['success']) ?>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
# Filing a pull request

> [!IMPORTANT]
> Do not create a pull request without creating an issue first (except if you are an officer of CITE). Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

**Types of change**

<!--- What types of change does your work introduce? -->
<!--- Place an 'X' between the brackets to check the item -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds or enhances functionality)
-   [ ] Documentation (non-breaking change which adds or changes documentation)
-   [ ] Refactor (non-breaking change that refactors a section of work)
-   [ ] Breaking change (either of the above that would cause existing functionality to not work as expected)

**Description**

<!--- Describe your changes in detail. Please link the issue ID as well. -->

- Improved error handling for oversized file uploads in lost and found item posting forms.
- Previously, oversized uploads caused CSRF validation to fail (since $_POST is empty), leading to confusing errors. Now, oversized uploads are detected early and handled with proper flash messages.
- Changed from plain error messages to styled error flags on the form page.