### PR TITLE
Feature/no ref/add archiving functionality to recovered items

### DIFF
--- a/src/Controllers/FoundItemController.php
+++ b/src/Controllers/FoundItemController.php
@@ -64,7 +64,7 @@ class FoundItemController
                 'can_archive' => isset($_SESSION['user_id'], $item['user_id'])
                     && (int)$item['user_id'] === (int)$_SESSION['user_id']
                     && ($item['item_type'] ?? 'found') === 'found'
-                    && ($item['status'] ?? 'Unrecovered') !== 'Archived',
+                    && ($item['status'] ?? '') !== 'Archived',
             ];
         }, $rawItems);
 

--- a/src/Controllers/LostItemController.php
+++ b/src/Controllers/LostItemController.php
@@ -64,7 +64,7 @@ class LostItemController
                 'can_archive' => isset($_SESSION['user_id'], $item['user_id'])
                     && (int)$item['user_id'] === (int)$_SESSION['user_id']
                     && ($item['item_type'] ?? 'lost') === 'lost'
-                    && ($item['status'] ?? 'Unrecovered') !== 'Archived',
+                    && ($item['status'] ?? '') !== 'Archived',
             ];
         }, $rawItems);
 

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -33,6 +33,9 @@ class ProfileController{
                 'can_recover' => (int)($item['user_id'] ?? 0) === (int)$id
                     && ($item['status'] ?? 'Unrecovered') === 'Unrecovered'
                     && ($item['item_type'] ?? 'lost') === 'lost',
+                'can_archive' => (int)($item['user_id'] ?? 0) === (int)$id
+                    && ($item['item_type'] ?? 'lost') === 'lost'
+                    && ($item['status'] ?? '') !== 'Archived', 
             ]);
         }, $user->fetchItems($id, "lost"));
         $foundItems = array_map(function ($item) use ($id) {
@@ -48,6 +51,9 @@ class ProfileController{
                 'can_recover' => (int)($item['user_id'] ?? 0) === (int)$id
                     && ($item['status'] ?? 'Unrecovered') === 'Unrecovered'
                     && ($item['item_type'] ?? 'found') === 'found',
+                'can_archive' => (int)($item['user_id'] ?? 0) === (int)$id
+                    && ($item['item_type'] ?? 'found') === 'found'
+                    && ($item['status'] ?? '') !== 'Archived', 
             ]);
         }, $user->fetchItems($id, "found"));
 

--- a/src/Models/FoundItemModel.php
+++ b/src/Models/FoundItemModel.php
@@ -22,7 +22,7 @@ class FoundItemModel
                 SET status = 'Archived',
                     archive_date = NOW()
                 WHERE item_type = 'found'
-                AND status = 'Unrecovered' 
+                AND status IN ('Unrecovered', 'Recovered') 
                 AND archive_date IS NOT NULL 
                 AND archive_date <= NOW()";
         $this->db->exec($sql);

--- a/src/Models/LostItemModel.php
+++ b/src/Models/LostItemModel.php
@@ -70,7 +70,7 @@ class LostItemModel
                 SET status = 'Archived',
                     archive_date = NOW()
                 WHERE item_type = 'lost'
-                AND status = 'Unrecovered'
+                AND status IN ('Unrecovered', 'Recovered')
                 AND archive_date IS NOT NULL
                 AND archive_date <= NOW()";
         $this->db->exec($sql);

--- a/src/Views/mainpages/profile.php
+++ b/src/Views/mainpages/profile.php
@@ -192,7 +192,7 @@
             <?php
                 $lostBulkAvailable = false;
                 foreach ($lostItems ?? [] as $item) {
-                    if (!empty($item['can_recover'])) {
+                    if (!empty($item['can_archive'])) {
                         $lostBulkAvailable = true;
                         break;
                     }
@@ -200,7 +200,7 @@
 
                 $foundBulkAvailable = false;
                 foreach ($foundItems ?? [] as $item) {
-                    if (!empty($item['can_recover'])) {
+                    if (!empty($item['can_archive'])) {
                         $foundBulkAvailable = true;
                         break;
                     }
@@ -273,7 +273,7 @@
                                         </h3>
                                         <p class="text-sm"><?= date("F, j, Y", strtotime($item['event_date'])) ?></p>
                                     </div>
-                                    <?php if (!empty($item['can_recover'])): ?>
+                                    <?php if (!empty($item['can_archive'])): ?>
                                     <label class="bulk-archive-box absolute top-2 right-0 hidden cursor-pointer">
                                         <input type="checkbox"
                                             name="item_ids[]"
@@ -325,37 +325,43 @@
                                     </p>
                                 </div>
 
-                                <?php if (!empty($item['can_recover'])): ?>
+                                <?php if (!empty($item['can_archive'])): ?>
                                     <button type="button"
                                         class="mt-6 w-full min-h-[52px] rounded-[16px] bg-[#055BA8] px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
                                         onclick="openModal('recover-modal-<?= $item['id'] ?>')">
-                                        Mark as Recovered
+                                        <?= ($item['status'] === 'Recovered') ? 'Archive Item' : 'Mark as Recovered' ?>
                                     </button>
                                 <?php endif; ?>
 
-                                <?php if (!empty($item['can_recover'])): ?>
+                                <?php if (!empty($item['can_archive'])): ?>
                                                     <div id="recover-modal-<?= $item['id'] ?>" data-modal="true" class="hidden fixed inset-0 z-50 items-center justify-center bg-black/40 p-4">
                                                         <div class="w-full max-w-lg overflow-hidden rounded-[2rem] border border-slate-200 bg-white p-6 shadow-[0_20px_50px_rgba(15,23,42,0.18)] space-y-6">
                                                             <header class="relative space-y-2 border-b border-slate-200 pb-4">
                                                                 <button type="button" aria-label="Close" rel="prev" onclick="closeModal('recover-modal-<?= $item['id'] ?>')" class="absolute right-0 top-0 text-slate-500 transition hover:text-slate-900">×</button>
                                                                 <h3 class="text-xl font-semibold text-slate-900">
-                                                            Confirm Lost Item Recovery</h3>
+                                                                    <?= $item['status'] === 'Recovered' ? 'Confirm Lost Item Archival' : 'Confirm Lost Item Recovery' ?>
+                                                                </h3>
                                             </header>
                                             <div class="space-y-3">
                                                 <p class="text-sm leading-7 text-slate-700">
-                                                    Are you sure you want to mark this lost item as recovered? This will update its status for everyone.
+                                                    <?= $item['status'] === 'Recovered' 
+                                                        ? 'Are you sure you want to archive this lost item? This will remove the item from all listing pages.'
+                                                        : 'Are you sure you want to mark this lost item as recovered? This will update its status for everyone.' 
+                                                    ?>
                                                 </p>
                                                 <?php if (!empty($item['archive_date'])): ?>
                                                     <p class="text-sm text-slate-500">This post will be archived on <strong class="text-slate-900"><?= htmlspecialchars($item['archive_date']) ?></strong>.</p>
                                                 <?php endif; ?>
                                             </div>
                                             <footer class="flex flex-wrap justify-end gap-3 pt-4">
+                                            <?php if (!empty($item['can_recover'])): ?>    
                                                 <form method="POST" action="/lost/recover" class="inline-flex">
                                                     <?php \App\Core\Router::setCsrf(); ?>
                                                     <input type="hidden" name="item_id" value="<?= (int)$item['id'] ?>">
                                                     <input type="hidden" name="redirect_to" value="/profile#lost">
                                                     <button type="submit" class="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700">Yes, mark as recovered</button>
                                                 </form>
+                                            <?php endif; ?>
 
                                                 <form method="POST" action="/lost/archive" class="inline-flex">
                                                     <?php \App\Core\Router::setCsrf(); ?>
@@ -454,7 +460,7 @@
                                     </h3>
                                     <p class="text-sm"><?= date("F, j, Y", strtotime($item['event_date'])) ?></p>
                                 </div>
-                                <?php if (!empty($item['can_recover'])): ?>
+                                <?php if (!empty($item['can_archive'])): ?>
                                     <label class="bulk-archive-box absolute top-2 right-0 hidden cursor-pointer">
                                         <input type="checkbox"
                                             name="item_ids[]"
@@ -507,36 +513,43 @@
                                     </p>
                                 </div>
 
-                                <?php if (!empty($item['can_recover'])): ?>
+                                <?php if (!empty($item['can_archive'])): ?>
                                     <button type="button"
                                         class="mt-6 w-full min-h-[52px] rounded-[16px] bg-[#055BA8] px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
                                         onclick="openModal('recover-found-modal-<?= $item['id'] ?>')">
-                                        Mark as Recovered
+                                        <?= ($item['status'] === 'Recovered') ? 'Archive Item' : 'Mark as Recovered' ?>
                                     </button>
                                 <?php endif; ?>
 
-                                <?php if (!empty($item['can_recover'])): ?>
+                                <?php if (!empty($item['can_archive'])): ?>
                                     <div id="recover-found-modal-<?= $item['id'] ?>" data-modal="true" class="hidden fixed inset-0 z-50 items-center justify-center bg-black/40 p-4">
                                         <div class="w-full max-w-lg overflow-hidden rounded-[2rem] border border-slate-200 bg-white p-6 shadow-[0_20px_50px_rgba(15,23,42,0.18)] space-y-6">
                                             <header class="relative space-y-2 border-b border-slate-200 pb-4">
                                                 <button type="button" aria-label="Close" rel="prev" onclick="closeModal('recover-found-modal-<?= $item['id'] ?>')" class="absolute right-0 top-0 text-slate-500 transition hover:text-slate-900">×</button>
-                                                <h3 class="text-xl font-semibold text-slate-900">Confirm Found Item Recovery</h3>
+                                                <h3 class="text-xl font-semibold text-slate-900">
+                                                    <?= $item['status'] === 'Recovered' ? 'Confirm Found Item Archival' : 'Confirm Found Item Recovery' ?>
+                                                </h3>
                                             </header>
                                             <div class="space-y-3">
                                                 <p class="text-sm leading-7 text-slate-700">
-                                                    Are you sure you want to mark this found item as recovered? This will update its status for everyone.
+                                                    <?= $item['status'] === 'Recovered' 
+                                                        ? 'Are you sure you want to archive this found item? This will remove the item from all listing pages.'
+                                                        : 'Are you sure you want to mark this found item as recovered? This will update its status for everyone.' 
+                                                    ?>
                                                 </p>
                                                 <?php if (!empty($item['archive_date'])): ?>
                                                     <p class="text-sm text-slate-500">This post will be archived on <strong class="text-slate-900"><?= htmlspecialchars($item['archive_date']) ?></strong>.</p>
                                                 <?php endif; ?>
                                             </div>
                                             <footer class="flex flex-wrap justify-end gap-3 pt-4">
+                                                <?php if (!empty($item['can_recover'])): ?>
                                                 <form method="POST" action="/found/recover" class="inline-flex">
                                                     <?php \App\Core\Router::setCsrf(); ?>
                                                     <input type="hidden" name="item_id" value="<?= (int)$item['id'] ?>">
                                                     <input type="hidden" name="redirect_to" value="/profile#found">
                                                     <button type="submit" class="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700">Yes, mark as recovered</button>
                                                 </form>
+                                                <?php endif; ?>
 
                                                 <form method="POST" action="/found/archive" class="inline-flex">
                                                     <?php \App\Core\Router::setCsrf(); ?>


### PR DESCRIPTION
# Filing a pull request

> [!IMPORTANT]
> Do not create a pull request without creating an issue first (except if you are an officer of CITE). Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

**Types of change**

<!--- What types of change does your work introduce? -->
<!--- Place an 'X' between the brackets to check the item -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds or enhances functionality)
-   [ ] Documentation (non-breaking change which adds or changes documentation)
-   [ ] Refactor (non-breaking change that refactors a section of work)
-   [ ] Breaking change (either of the above that would cause existing functionality to not work as expected)

**Description**

<!--- Describe your changes in detail. Please link the issue ID as well. -->

Added archiving functionality for recovered items.

Changes
  - Auto-archiving after 30 days now also applies to recovered items, unless manually/archived.
  - Recovered items can now be included in multiple/bulk archive selections.
  - When an item is marked as recovered, "Archive Item" button appears in card instead of "Mark as Recovered" button.
 - Added dynamic modal title and confirmation message based on item status.
 
 Note:
 - Recovery status tag is not applied here yet. Will apply in a another pull request along with other UI updates to lost and found item cards.