### PR TITLE
Bugfix: Strict validation for duplicate emails in registration

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -189,12 +189,13 @@ class AuthController{
 
             // Email Verification Scenarios
             if($user){
-                // [1] Email already exists
-                if($user['email_verified'] == 1){
-                    $errors['wvsu_email'] =  "✕ The '$email' is already in use.";
+                // [1] Email already exists and is verified
+                if((int)$user['email_verified'] === 1){
+                    $errors['wvsu_email'] =  "✕ The email address '$email' is already in use.";
+                } else {
+                    // [2] Email already exists but not verified -> Direct to login
+                    $errors['wvsu_email'] = "✕ This email is already registered but unverified. Please log in to continue.";
                 }
-                // [2] Email already exists but not verified -> Update OTP and allow re-registration
-                $model->updateOtp($email, $v_code_hashed, $expires);
             }
             // NOTE: Do NOT create user yet! Defer creation until OTP verification to prevent database spam.
             // This prevents attackers from filling the database with unverified accounts.
@@ -292,12 +293,20 @@ class AuthController{
             return;
         }
         
-        $userId = $model->create($registrationData);
-        
-        // Mark email as verified immediately after creation
-        if (!$model->verifyOtp($email, $otp)) {
-            echo "Registration completed but verification status failed to update. Try and login to verify your account.";
-            return;
+        try {
+            $userId = $model->create($registrationData);
+            
+            // Mark email as verified immediately after creation
+            if (!$model->verifyOtp($email, $otp)) {
+                echo "Registration completed but verification status failed to update. Try and login to verify your account.";
+                return;
+            }
+        } catch (PDOException $e) {
+            if ($e->errorInfo[1] === 1062) {
+                echo "Registration failed: The email address '$email' is already in use.";
+                return;
+            }
+            throw $e;
         }
         
         // Set session for authenticated user


### PR DESCRIPTION
**Types of change**
- [x] Bug fix

**Description**

Related to #61 

This PR is a work in progress to fix the duplicate email registration issue.

**Problem**
Currently, users can register with an email that already exists, and the system still shows a "Registration successful" message. This can be confusing and misleading.

**Current approach**
- Checking if the email already exists during registration
- Showing an error message if the email is already used
- Handling unverified accounts differently (prompting users to log in instead)

Still open to feedback on the approach before finalizing.