### PR TITLE
Bugfix/issue 61/strict validation for duplicate emails in registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 apache2/
 mysql/
 
+logs/*.log
+
 vendor/
 node_modules/
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -189,12 +189,13 @@ class AuthController{
 
             // Email Verification Scenarios
             if($user){
-                // [1] Email already exists
-                if($user['email_verified'] == 1){
-                    $errors['wvsu_email'] =  "✕ The '$email' is already in use.";
+                // [1] Email already exists and is verified
+                if((int)$user['email_verified'] === 1){
+                    $errors['wvsu_email'] =  "✕ The email address '$email' is already in use.";
+                } else {
+                    // [2] Email already exists but not verified -> Direct to login
+                    $errors['wvsu_email'] = "✕ This email is already registered but unverified. Please log in to continue.";
                 }
-                // [2] Email already exists but not verified -> Update OTP and allow re-registration
-                $model->updateOtp($email, $v_code_hashed, $expires);
             }
             // NOTE: Do NOT create user yet! Defer creation until OTP verification to prevent database spam.
             // This prevents attackers from filling the database with unverified accounts.
@@ -292,12 +293,20 @@ class AuthController{
             return;
         }
         
-        $userId = $model->create($registrationData);
-        
-        // Mark email as verified immediately after creation
-        if (!$model->verifyOtp($email, $otp)) {
-            echo "Registration completed but verification status failed to update. Try and login to verify your account.";
-            return;
+        try {
+            $userId = $model->create($registrationData);
+            
+            // Mark email as verified immediately after creation
+            if (!$model->verifyOtp($email, $otp)) {
+                echo "Registration completed but verification status failed to update. Try and login to verify your account.";
+                return;
+            }
+        } catch (PDOException $e) {
+            if ($e->errorInfo[1] === 1062) {
+                echo "Registration failed: The email address '$email' is already in use.";
+                return;
+            }
+            throw $e;
         }
         
         // Set session for authenticated user

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -3,6 +3,11 @@
     * Layer: Controller
     * Purpose: Handle HTTP requests and responses
     * Rules: No direct DB queries or HTML markup
+
+    * logs/
+    * ├── .gitkeep
+    * ├── php_errors.log        # PHP core errors (php.ini configured)
+    * └── database_errors.log       # Database exceptions caught in controllers
 */
 
 namespace App\Controllers;
@@ -236,12 +241,15 @@ class AuthController{
             if ($e->errorInfo[1] === 1062) {
                 echo "Registration failed: The email address '$email' is already in use.";
             } else {
-                error_log("Database Error: " . $e->getMessage());
-                echo "An unexpected error occurred during registration. Please try again later." . $e->getMessage();
+                error_log($e->getMessage(), 3, __DIR__ . "/../../logs/database_errors.log");
+                // TODO: Replace with proper 500 error page
+                echo "500 Error: An unexpected error occurred during registration. Please try again later.";
             }
         } catch (Exception $e) {
             // General Error Handling (Validation, etc.)
-            echo "Error: " . $e->getMessage();
+            error_log($e->getMessage(), 3, __DIR__ . "/../../logs/php_errors.log");
+            // TODO: Replace with proper 500 error page
+            echo "500 Error: An unexpected error occurred. Please try again later.";
         }
     }
 
@@ -306,7 +314,10 @@ class AuthController{
                 echo "Registration failed: The email address '$email' is already in use.";
                 return;
             }
-            throw $e;
+            // TODO: Replace with proper 500 error page
+            error_log($e->getMessage(), 3, __DIR__ . "/../../logs/database_errors.log");
+            echo "500 Error: An unexpected error occurred. Please try again later.";
+            return;
         }
         
         // Set session for authenticated user

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -194,7 +194,7 @@ class AuthController{
                     $errors['wvsu_email'] =  "✕ The email address '$email' is already in use.";
                 } else {
                     // [2] Email already exists but not verified -> Direct to login
-                    $errors['wvsu_email'] = "✕ This email is already registered but unverified. Please log in to continue.";
+                    $errors['wvsu_email'] = "✕ The email address '$email' already registered but unverified. Please log in to continue.";
                 }
             }
             // NOTE: Do NOT create user yet! Defer creation until OTP verification to prevent database spam.

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -241,13 +241,29 @@ class AuthController{
             if ($e->errorInfo[1] === 1062) {
                 echo "Registration failed: The email address '$email' is already in use.";
             } else {
-                error_log($e->getMessage(), 3, __DIR__ . "/../../logs/database_errors.log");
+                // TODO: Create a logger class to handle this instead of raw error_log calls in controllers
+                $logEntry = sprintf(
+                    "[%s] ERROR | File: %s | Line: %d | Message: %s\n",
+                    date('Y-m-d H:i:s'),
+                    $e->getFile(),
+                    $e->getLine(),
+                    $e->getMessage()
+                );
+                error_log($logEntry, 3, __DIR__ . "/../../logs/database_errors.log");
                 // TODO: Replace with proper 500 error page
                 echo "500 Error: An unexpected error occurred during registration. Please try again later.";
             }
         } catch (Exception $e) {
             // General Error Handling (Validation, etc.)
-            error_log($e->getMessage(), 3, __DIR__ . "/../../logs/php_errors.log");
+            // TODO: Create a logger class to handle this instead of raw error_log calls in controllers
+            $logEntry = sprintf(
+                "[%s] ERROR | File: %s | Line: %d | Message: %s\n",
+                date('Y-m-d H:i:s'),
+                $e->getFile(),
+                $e->getLine(),
+                $e->getMessage()
+            );
+            error_log($logEntry, 3, __DIR__ . "/../../logs/php_errors.log");
             // TODO: Replace with proper 500 error page
             echo "500 Error: An unexpected error occurred. Please try again later.";
         }
@@ -315,7 +331,14 @@ class AuthController{
                 return;
             }
             // TODO: Replace with proper 500 error page
-            error_log($e->getMessage(), 3, __DIR__ . "/../../logs/database_errors.log");
+            $logEntry = sprintf(
+                "[%s] ERROR | File: %s | Line: %d | Message: %s\n",
+                date('Y-m-d H:i:s'),
+                $e->getFile(),
+                $e->getLine(),
+                $e->getMessage()
+            );
+            error_log($logEntry, 3, __DIR__ . "/../../logs/database_errors.log");
             echo "500 Error: An unexpected error occurred. Please try again later.";
             return;
         }

--- a/src/Views/auth/register.php
+++ b/src/Views/auth/register.php
@@ -61,7 +61,7 @@
                     <label class="text-sm font-semibold text-primary" for="email">WVSU Email Address</label>
                     <input type="email" name="email" id="email" required
                            class="w-full px-4 py-2 text-sm border <?= !empty($errors['wvsu_email']) ? 'border-red-500 border-2' : 'border-white-700' ?> rounded-lg bg-white placeholder-secondary">
-                    <p class="text-sm text-red-500">
+                    <p class="text-sm text-red-500 break-all">
                         <?= $errors['wvsu_email'] ?? '' ?>
                     </p>
                 </div>


### PR DESCRIPTION
**Types of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Description**
This PR improves registration validation by enforcing strict duplicate email handling during user registration.

Previously, duplicate email cases could pass through inconsistent validation paths depending on the verification state (verified vs unverified accounts), which could lead to ambiguous registration behavior.

This update standardizes email validation logic to ensure:
- Existing verified emails are blocked from re-registration
- Unverified emails are properly handled with a clear error message
- Consistent validation flow before OTP generation and user creation

The changes ensure that duplicate email scenarios are handled and prevent conflicting registration states.

Closes #61